### PR TITLE
Add link-based tunnel import

### DIFF
--- a/ui/src/main/java/com/wireguard/android/fragment/AddTunnelsSheet.kt
+++ b/ui/src/main/java/com/wireguard/android/fragment/AddTunnelsSheet.kt
@@ -61,6 +61,10 @@ class AddTunnelsSheet : BottomSheetDialogFragment() {
                     dismiss()
                     onRequestCreateConfig()
                 }
+                dialog.findViewById<View>(R.id.create_from_link)?.setOnClickListener {
+                    dismiss()
+                    onRequestLinkConfig()
+                }
                 dialog.findViewById<View>(R.id.create_from_file)?.setOnClickListener {
                     dismiss()
                     onRequestImportConfig()
@@ -94,11 +98,16 @@ class AddTunnelsSheet : BottomSheetDialogFragment() {
         setFragmentResult(REQUEST_KEY_NEW_TUNNEL, bundleOf(REQUEST_METHOD to REQUEST_SCAN))
     }
 
+    private fun onRequestLinkConfig() {
+        setFragmentResult(REQUEST_KEY_NEW_TUNNEL, bundleOf(REQUEST_METHOD to REQUEST_LINK))
+    }
+
     companion object {
         const val REQUEST_KEY_NEW_TUNNEL = "request_new_tunnel"
         const val REQUEST_METHOD = "request_method"
         const val REQUEST_CREATE = "request_create"
         const val REQUEST_IMPORT = "request_import"
         const val REQUEST_SCAN = "request_scan"
+        const val REQUEST_LINK = "request_link"
     }
 }

--- a/ui/src/main/java/com/wireguard/android/fragment/TunnelListFragment.kt
+++ b/ui/src/main/java/com/wireguard/android/fragment/TunnelListFragment.kt
@@ -22,6 +22,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.view.ActionMode
 import androidx.lifecycle.lifecycleScope
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import com.google.zxing.qrcode.QRCodeReader
 import com.journeyapps.barcodescanner.ScanContract
@@ -32,6 +33,7 @@ import com.wireguard.android.activity.TunnelCreatorActivity
 import com.wireguard.android.databinding.ObservableKeyedRecyclerViewAdapter.RowConfigurationHandler
 import com.wireguard.android.databinding.TunnelListFragmentBinding
 import com.wireguard.android.databinding.TunnelListItemBinding
+import com.wireguard.android.databinding.LinkImportDialogFragmentBinding
 import com.wireguard.android.model.ObservableTunnel
 import com.wireguard.android.updater.SnackbarUpdateShower
 import com.wireguard.android.util.ErrorMessages
@@ -42,6 +44,12 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import java.io.IOException
+import java.net.HttpURLConnection
+import java.net.URL
 
 /**
  * Fragment containing a list of known WireGuard tunnels. It allows creating and deleting tunnels.
@@ -121,6 +129,10 @@ class TunnelListFragment : BaseFragment() {
                                     .setBeepEnabled(false)
                                     .setPrompt(getString(R.string.qr_code_hint))
                             )
+                        }
+
+                        AddTunnelsSheet.REQUEST_LINK -> {
+                            showImportFromLinkDialog()
                         }
                     }
                 }
@@ -202,6 +214,44 @@ class TunnelListFragment : BaseFragment() {
                 .show()
         else
             Toast.makeText(activity ?: Application.get(), message, Toast.LENGTH_SHORT).show()
+    }
+
+    private fun showImportFromLinkDialog() {
+        val activity = activity ?: return
+        val binding = LinkImportDialogFragmentBinding.inflate(activity.layoutInflater, null, false)
+        MaterialAlertDialogBuilder(activity)
+            .setTitle(R.string.import_from_link)
+            .setView(binding.root)
+            .setNegativeButton(R.string.cancel, null)
+            .setPositiveButton(R.string.connect) { _, _ ->
+                val url = binding.linkText.text?.toString()?.trim() ?: ""
+                if (url.isEmpty()) return@setPositiveButton
+                activity.lifecycleScope.launch {
+                    try {
+                        val config = fetchConfigFromUrl(url)
+                        TunnelImporter.importTunnel(parentFragmentManager, config) { showSnackbar(it) }
+                    } catch (e: Exception) {
+                        showSnackbar(getString(R.string.fetch_config_error, e.message))
+                    }
+                }
+            }
+            .show()
+    }
+
+    private suspend fun fetchConfigFromUrl(urlString: String): String = withContext(Dispatchers.IO) {
+        val connection = URL(urlString).openConnection() as HttpURLConnection
+        connection.connectTimeout = 15000
+        connection.readTimeout = 15000
+        try {
+            if (connection.responseCode != HttpURLConnection.HTTP_OK) {
+                throw IOException("HTTP ${'$'}{connection.responseCode}")
+            }
+            val response = connection.inputStream.bufferedReader().use { it.readText() }
+            val json = JSONObject(response)
+            json.getString("config")
+        } finally {
+            connection.disconnect()
+        }
     }
 
     private fun viewForTunnel(tunnel: ObservableTunnel, tunnels: List<*>): MultiselectableRelativeLayout? {

--- a/ui/src/main/res/drawable/ic_action_link.xml
+++ b/ui/src/main/res/drawable/ic_action_link.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright © 2017-2025 WireGuard LLC. All Rights Reserved.
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M3.9,12c0,1.71 1.39,3.1 3.1,3.1h3v1.9H7c-2.76,0-5-2.24-5-5s2.24-5 5-5h3v1.9H7c-1.71,0-3.1,1.39-3.1,3.1zM8,13h8v-2H8v2zm9-6h-3v1.9h3c1.71,0,3.1,1.39,3.1,3.1s-1.39,3.1-3.1,3.1h-3v1.9h3c2.76,0,5-2.24,5-5s-2.24-5-5-5z" />
+</vector>

--- a/ui/src/main/res/layout/add_tunnels_bottom_sheet.xml
+++ b/ui/src/main/res/layout/add_tunnels_bottom_sheet.xml
@@ -10,6 +10,29 @@
     android:paddingTop="@dimen/bottom_sheet_top_padding">
 
     <com.google.android.material.button.MaterialButton
+        android:id="@+id/create_from_link"
+        style="@style/Widget.Material3.Button.TextButton.Icon"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/bottom_sheet_item_height"
+        android:layout_marginStart="@dimen/normal_margin"
+        android:layout_marginLeft="@dimen/normal_margin"
+        android:layout_marginEnd="@dimen/normal_margin"
+        android:layout_marginRight="@dimen/normal_margin"
+        android:nextFocusDown="@id/create_from_file"
+        android:nextFocusForward="@id/create_from_file"
+        android:text="@string/create_from_link"
+        android:textAlignment="viewStart"
+        android:textColor="?attr/colorOnSurface"
+        app:icon="@drawable/ic_action_link"
+        app:iconPadding="@dimen/bottom_sheet_icon_padding"
+        app:iconTint="?attr/colorSecondary"
+        app:layout_constraintBottom_toTopOf="@+id/create_from_file"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="parent"
+        app:rippleColor="?attr/colorSecondary" />
+
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/create_from_file"
         style="@style/Widget.Material3.Button.TextButton.Icon"
         android:layout_width="match_parent"
@@ -18,6 +41,7 @@
         android:layout_marginLeft="@dimen/normal_margin"
         android:layout_marginEnd="@dimen/normal_margin"
         android:layout_marginRight="@dimen/normal_margin"
+        android:nextFocusUp="@id/create_from_link"
         android:nextFocusDown="@id/create_from_qrcode"
         android:nextFocusForward="@id/create_from_qrcode"
         android:text="@string/create_from_file"
@@ -29,7 +53,7 @@
         app:layout_constraintBottom_toTopOf="@+id/create_from_qrcode"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/create_from_link"
         app:rippleColor="?attr/colorSecondary" />
 
     <com.google.android.material.button.MaterialButton

--- a/ui/src/main/res/layout/link_import_dialog_fragment.xml
+++ b/ui/src/main/res/layout/link_import_dialog_fragment.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright © 2017-2025 WireGuard LLC. All Rights Reserved.
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:padding="16dp">
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/link_text_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/link_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/config_url_hint"
+                android:imeOptions="actionDone"
+                android:inputType="textUri">
+
+                <requestFocus />
+            </com.google.android.material.textfield.TextInputEditText>
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+    </FrameLayout>
+
+</layout>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -98,6 +98,7 @@
     <string name="create_downloads_file_error">Cannot create file in downloads directory</string>
     <string name="create_empty">Create from scratch</string>
     <string name="create_from_file">Import from file or archive</string>
+    <string name="create_from_link">Import from link</string>
     <string name="create_from_qr_code">Scan from QR code</string>
     <string name="create_output_dir_error">Cannot create output directory</string>
     <string name="create_temp_dir_error">Cannot create local temporary directory</string>
@@ -136,6 +137,7 @@
     <string name="illegal_filename_error">Illegal file name “%s”</string>
     <string name="import_error">Unable to import tunnel: %s</string>
     <string name="import_from_qr_code">Import Tunnel from QR Code</string>
+    <string name="import_from_link">Import Tunnel from Link</string>
     <string name="import_success">Imported “%s”</string>
     <string name="interface_title">Interface</string>
     <string name="key_contents_error">Bad characters in key</string>
@@ -198,6 +200,9 @@
     <string name="save">Save</string>
     <string name="select_all">Select all</string>
     <string name="settings">Settings</string>
+    <string name="connect">Connect</string>
+    <string name="config_url_hint">Configuration URL</string>
+    <string name="fetch_config_error">Unable to fetch configuration: %s</string>
     <string name="shell_exit_status_read_error">Shell cannot read exit status</string>
     <string name="shell_marker_count_error">Shell expected 4 markers, received %d</string>
     <string name="shell_start_error">Shell failed to start: %d</string>


### PR DESCRIPTION
## Summary
- allow creating tunnels by importing configuration from a URL link
- add dialog to fetch configuration JSON and import the tunnel
- include new resources and strings for link-based import

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899eb23b228832fb54d0ea499c3d3f2